### PR TITLE
[logs-dispatcher] pin kubernetes_metadata_filter to 2.10.0

### DIFF
--- a/logs-dispatcher/Dockerfile
+++ b/logs-dispatcher/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --no-cache --update --virtual .build-deps \
       && gem sources --update \
       && gem install fluent-plugin-cloudwatch-logs \
       && gem install fluent-plugin-datadog \
-      && gem install fluent-plugin-kubernetes_metadata_filter \
+      && gem install fluent-plugin-kubernetes_metadata_filter -v 2.12.0 \
       && gem install fluent-plugin-multi-format-parser \
       && gem install fluent-plugin-prometheus \
       && gem install fluent-plugin-rabbitmq \

--- a/logs-dispatcher/Dockerfile
+++ b/logs-dispatcher/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --no-cache --update --virtual .build-deps \
       && gem sources --update \
       && gem install fluent-plugin-cloudwatch-logs \
       && gem install fluent-plugin-datadog \
-      && gem install fluent-plugin-kubernetes_metadata_filter -v 2.12.0 \
+      && gem install fluent-plugin-kubernetes_metadata_filter -v 2.10.0 \
       && gem install fluent-plugin-multi-format-parser \
       && gem install fluent-plugin-prometheus \
       && gem install fluent-plugin-rabbitmq \


### PR DESCRIPTION
In https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter/issues/320 the kubernetes_metadata_filter removed the ability to dedot labels natively. 

We will undergo some tests to see if there are alternate solutions - we maybe don't need to dedot them now?

in the meantime, this pins the logs-dispatcher to a version that works