### PR TITLE
add mongodb-tools from 3.17

### DIFF
--- a/database-tools/Dockerfile
+++ b/database-tools/Dockerfile
@@ -1,8 +1,14 @@
 FROM alpine:3.18.4
-RUN apk add --no-cache bash \
+
+LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-service-images" repository="https://github.com/uselagoon/lagoon-service-images"
+
+RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.17/community' >> /etc/apk/repositories \
+	&& apk update \
+	&& apk add --no-cache bash \
 	grep \
 	sed \
+	mongodb-tools=4.2.14-r17 \
 	mysql-client \
-	mongodb-tools \
 	postgresql-client \
 	&& rm -rf /var/cache/apk/*


### PR DESCRIPTION
The later releases of mongodb-tools have known issues with documentdb, so this pr downgrades the bundled version to a known good version.

Ref: https://repost.aws/questions/QUeugcS1E8QHukyrP3IY658w/documentdb-4-0-mongodump-error-checking-for-atlasproxy-unknown-admin-command-atlasversion