### PR TITLE
chore: disable fine-grained github_token permissions

### DIFF
--- a/.github/workflows/athenapdf-service-image.yaml
+++ b/.github/workflows/athenapdf-service-image.yaml
@@ -17,14 +17,13 @@ on:
       - 'athenapdf-service/**'
       - '.github/workflows/athenapdf-service-image.yaml'
 
-
 jobs:
   docker:
-    permissions:
-      attestations: write
-      contents: write
-      id-token: write
-      packages: write
+    # permissions:
+    #   attestations: write
+    #   contents: write
+    #   id-token: write
+    #   packages: write
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/athenapdf-service-image.yaml
+++ b/.github/workflows/athenapdf-service-image.yaml
@@ -19,11 +19,7 @@ on:
 
 jobs:
   docker:
-    # permissions:
-    #   attestations: write
-    #   contents: write
-    #   id-token: write
-    #   packages: write
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/database-tools-image.yaml
+++ b/.github/workflows/database-tools-image.yaml
@@ -19,11 +19,11 @@ on:
 
 jobs:
   docker:
-    permissions:
-      attestations: write
-      contents: write
-      id-token: write
-      packages: write
+    # permissions:
+    #   attestations: write
+    #   contents: write
+    #   id-token: write
+    #   packages: write
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/database-tools-image.yaml
+++ b/.github/workflows/database-tools-image.yaml
@@ -19,11 +19,7 @@ on:
 
 jobs:
   docker:
-    # permissions:
-    #   attestations: write
-    #   contents: write
-    #   id-token: write
-    #   packages: write
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/docker-host-image.yaml
+++ b/.github/workflows/docker-host-image.yaml
@@ -19,11 +19,11 @@ on:
 
 jobs:
   docker:
-    permissions:
-      attestations: write
-      contents: write
-      id-token: write
-      packages: write
+    # permissions:
+    #   attestations: write
+    #   contents: write
+    #   id-token: write
+    #   packages: write
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/docker-host-image.yaml
+++ b/.github/workflows/docker-host-image.yaml
@@ -19,11 +19,7 @@ on:
 
 jobs:
   docker:
-    # permissions:
-    #   attestations: write
-    #   contents: write
-    #   id-token: write
-    #   packages: write
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/drush-alias-image.yaml
+++ b/.github/workflows/drush-alias-image.yaml
@@ -19,11 +19,11 @@ on:
 
 jobs:
   docker:
-    permissions:
-      attestations: write
-      contents: write
-      id-token: write
-      packages: write
+    # permissions:
+    #   attestations: write
+    #   contents: write
+    #   id-token: write
+    #   packages: write
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/drush-alias-image.yaml
+++ b/.github/workflows/drush-alias-image.yaml
@@ -19,11 +19,7 @@ on:
 
 jobs:
   docker:
-    # permissions:
-    #   attestations: write
-    #   contents: write
-    #   id-token: write
-    #   packages: write
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/insights-scanner-image.yaml
+++ b/.github/workflows/insights-scanner-image.yaml
@@ -19,11 +19,11 @@ on:
 
 jobs:
   docker:
-    permissions:
-      attestations: write
-      contents: write
-      id-token: write
-      packages: write
+    # permissions:
+    #   attestations: write
+    #   contents: write
+    #   id-token: write
+    #   packages: write
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/insights-scanner-image.yaml
+++ b/.github/workflows/insights-scanner-image.yaml
@@ -19,11 +19,7 @@ on:
 
 jobs:
   docker:
-    # permissions:
-    #   attestations: write
-    #   contents: write
-    #   id-token: write
-    #   packages: write
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/logs-concentrator-image.yaml
+++ b/.github/workflows/logs-concentrator-image.yaml
@@ -19,11 +19,11 @@ on:
 
 jobs:
   docker:
-    permissions:
-      attestations: write
-      contents: write
-      id-token: write
-      packages: write
+    # permissions:
+    #   attestations: write
+    #   contents: write
+    #   id-token: write
+    #   packages: write
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/logs-concentrator-image.yaml
+++ b/.github/workflows/logs-concentrator-image.yaml
@@ -19,11 +19,7 @@ on:
 
 jobs:
   docker:
-    # permissions:
-    #   attestations: write
-    #   contents: write
-    #   id-token: write
-    #   packages: write
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/logs-dispatcher-image.yaml
+++ b/.github/workflows/logs-dispatcher-image.yaml
@@ -19,11 +19,11 @@ on:
 
 jobs:
   docker:
-    permissions:
-      attestations: write
-      contents: write
-      id-token: write
-      packages: write
+    # permissions:
+    #   attestations: write
+    #   contents: write
+    #   id-token: write
+    #   packages: write
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/logs-dispatcher-image.yaml
+++ b/.github/workflows/logs-dispatcher-image.yaml
@@ -19,11 +19,7 @@ on:
 
 jobs:
   docker:
-    # permissions:
-    #   attestations: write
-    #   contents: write
-    #   id-token: write
-    #   packages: write
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
       -


### PR DESCRIPTION
so...

If we set the fine-grained `permissions` block (needed to attest images), the GITHUB_TOKEN no longer has the permissions to access organisation-scoped secrets (such as the docker hub credentials shared by all repos) - clue was at https://github.com/orgs/community/discussions/12424

Will keep looking at what we can do to access both organisation-scoped secrets and the attest permissions.