### PR TITLE
chore: COPY app.conf with correct perms

### DIFF
--- a/drush-alias/Dockerfile
+++ b/drush-alias/Dockerfile
@@ -3,5 +3,5 @@ FROM uselagoon/nginx:latest
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-service-images" repository="https://github.com/uselagoon/lagoon-service-images"
 
-ADD nginx.conf /etc/nginx/conf.d/app.conf
-ADD web/ /app/
+COPY --chmod=664 nginx.conf /etc/nginx/conf.d/app.conf
+COPY web/ /app/


### PR DESCRIPTION
Newer versions of the upstream nginx image are fussier about the file perms for the app.conf - this PR fixes the permissions to match the rest of the folder.