### PR TITLE
chore: disable dockerhub image attestation

### DIFF
--- a/.github/workflows/athenapdf-service-image.yaml
+++ b/.github/workflows/athenapdf-service-image.yaml
@@ -114,12 +114,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      - name: Attest dockerhub image
-        uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
-        with:
-          subject-digest: ${{steps.build-and-push.outputs.digest}}
-          subject-name: index.docker.io/${{ github.repository_owner }}/athenapdf-service
-          push-to-registry: true
       - name: Attest ghcr image
         uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
         with:

--- a/.github/workflows/database-tools-image.yaml
+++ b/.github/workflows/database-tools-image.yaml
@@ -113,12 +113,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      - name: Attest dockerhub image
-        uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
-        with:
-          subject-digest: ${{steps.build-and-push.outputs.digest}}
-          subject-name: index.docker.io/${{ github.repository_owner }}/database-tools
-          push-to-registry: true
       - name: Attest ghcr image
         uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
         with:

--- a/.github/workflows/docker-host-image.yaml
+++ b/.github/workflows/docker-host-image.yaml
@@ -113,12 +113,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      - name: Attest dockerhub image
-        uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
-        with:
-          subject-digest: ${{steps.build-and-push.outputs.digest}}
-          subject-name: index.docker.io/${{ github.repository_owner }}/docker-host
-          push-to-registry: true
       - name: Attest ghcr image
         uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
         with:

--- a/.github/workflows/drush-alias-image.yaml
+++ b/.github/workflows/drush-alias-image.yaml
@@ -113,12 +113,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      - name: Attest dockerhub image
-        uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
-        with:
-          subject-digest: ${{steps.build-and-push.outputs.digest}}
-          subject-name: index.docker.io/${{ github.repository_owner }}/drush-alias
-          push-to-registry: true
       - name: Attest ghcr image
         uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
         with:

--- a/.github/workflows/insights-scanner-image.yaml
+++ b/.github/workflows/insights-scanner-image.yaml
@@ -113,12 +113,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      - name: Attest dockerhub image
-        uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
-        with:
-          subject-digest: ${{steps.build-and-push.outputs.digest}}
-          subject-name: index.docker.io/${{ github.repository_owner }}/insights-scanner
-          push-to-registry: true
       - name: Attest ghcr image
         uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
         with:

--- a/.github/workflows/insights-trivy-image.yaml
+++ b/.github/workflows/insights-trivy-image.yaml
@@ -120,12 +120,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      - name: Attest dockerhub image
-        uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
-        with:
-          subject-digest: ${{steps.build-and-push.outputs.digest}}
-          subject-name: index.docker.io/${{ github.repository_owner }}/insights-trivy
-          push-to-registry: true
       - name: Attest ghcr image
         uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
         with:

--- a/.github/workflows/logs-concentrator-image.yaml
+++ b/.github/workflows/logs-concentrator-image.yaml
@@ -113,12 +113,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      - name: Attest dockerhub image
-        uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
-        with:
-          subject-digest: ${{steps.build-and-push.outputs.digest}}
-          subject-name: index.docker.io/${{ github.repository_owner }}/logs-concentrator
-          push-to-registry: true
       - name: Attest ghcr image
         uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
         with:

--- a/.github/workflows/logs-dispatcher-image.yaml
+++ b/.github/workflows/logs-dispatcher-image.yaml
@@ -113,12 +113,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      - name: Attest dockerhub image
-        uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
-        with:
-          subject-digest: ${{steps.build-and-push.outputs.digest}}
-          subject-name: index.docker.io/${{ github.repository_owner }}/logs-dispatcher
-          push-to-registry: true
       - name: Attest ghcr image
         uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
         with:


### PR DESCRIPTION
Until dockerhub supports the OCI Referrers API, attestations attached to
images result in numerous noisy sha256-* tags. So disable dockerhub
image attestation for now.
